### PR TITLE
Fix ptsname return type

### DIFF
--- a/src/pty/ffi.rs
+++ b/src/pty/ffi.rs
@@ -29,5 +29,5 @@ extern "C" {
     pub fn posix_openpt(flags: libc::c_int) -> libc::c_int;
     pub fn grantpt(fd: libc::c_int) -> libc::c_int;
     pub fn unlockpt(fd: libc::c_int) -> libc::c_int;
-    pub fn ptsname(fd: libc::c_int) -> *mut libc::c_schar;
+    pub fn ptsname(fd: libc::c_int) -> *mut libc::c_char;
 }


### PR DESCRIPTION
Use platform char instead of specifying signedness.

Fixes #1 